### PR TITLE
Update trusted org to jetstack

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -7,7 +7,7 @@ triggers:
   - jetstack-experimental/cert-manager
   - jetstack/test-infra
   - jetstack/navigator
-  trusted_org: jetstack-experimental
+  trusted_org: jetstack
 
 # heart:
 #   adorees:


### PR DESCRIPTION
This is used for the 'ok-to-test required' comment
