### PR TITLE
Use libvirt instead of virtualbox

### DIFF
--- a/images/ruby-2.3/Dockerfile
+++ b/images/ruby-2.3/Dockerfile
@@ -16,17 +16,9 @@
 FROM ruby:2.3
 LABEL maintainer="christian.simon@jetstack.io"
 
-
-# Install virtualbox package url
-ADD https://www.virtualbox.org/download/oracle_vbox_2016.asc /tmp/oracle_vbox_2016.asc
-RUN echo "deb http://download.virtualbox.org/virtualbox/debian jessie contrib" > /etc/apt/sources.list.d/virtualbox.list \
- && cat /tmp/oracle_vbox_2016.asc | apt-key add -
-
 RUN apt-get update && apt-get install -y \
     python \
     git \
-    dkms \
-    virtualbox-5.1 \
     curl \
     zlib1g-dev \
     build-essential \
@@ -39,6 +31,7 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     libxml2-dev \
     libxslt1-dev \
+    libvirt-dev \
     libcurl4-openssl-dev \
     python-software-properties \
     libffi-dev \
@@ -49,16 +42,22 @@ RUN apt-get update && apt-get install -y \
 
 
 # Download and install vagrant
-RUN curl -sL -o /tmp/vagrant.deb https://releases.hashicorp.com/vagrant/1.9.5/vagrant_1.9.5_x86_64.deb \
- && echo "5c2d841c88589c929b6b24e8d7fc443b8b76c809c5ad600a7c192fc794fa329a  /tmp/vagrant.deb" | sha256sum -c \
+ENV VAGRANT_VERSION 2.0.1
+ENV VAGRANT_HASH 2f9498a83b3d650fcfcfe0ec7971070fcd3803fad6470cf7da871caf2564d84f
+RUN curl -sL -o /tmp/vagrant.deb https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb \
+ && echo "${VAGRANT_HASH}  /tmp/vagrant.deb" | sha256sum -c \
  && DEBIAN_FRONTEND=noninteractive dpkg -i /tmp/vagrant.deb \
  && rm /tmp/vagrant.deb
 
+# Download and install vagrant's libvirt plugin
+RUN vagrant plugin install vagrant-libvirt
 
-ENV GCLOUD_VERSION 163.0.0
-RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
-    tar xf google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz -C / && \
-    rm google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
+ENV GCLOUD_VERSION 178.0.0
+ENV GCLOUD_HASH 2e0bbbf81c11164bf892cf0b891751ba4e5172661eff907ad1f7fc0b6907e296
+RUN curl -sL -o /tmp/google-cloud-sdk.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \
+    echo "$GCLOUD_HASH  /tmp/google-cloud-sdk.tar.gz" | sha256sum -c && \
+    tar xf /tmp/google-cloud-sdk.tar.gz -C / && \
+    rm /tmp/google-cloud-sdk.tar.gz && \
     /google-cloud-sdk/install.sh
 ENV PATH "/google-cloud-sdk/bin:${PATH}"
 

--- a/images/ruby-2.3/Makefile
+++ b/images/ruby-2.3/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION = 0.4
+VERSION = 0.5
 
 image:
 	docker build -t "gcr.io/jetstack-build-infra/ruby-2.3:$(VERSION)" .

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -38,7 +38,7 @@ log_level: info
   agent: kubernetes
   spec:
     containers:
-    - image: gcr.io/jetstack-build-infra/ruby-2.3:0.4
+    - image: gcr.io/jetstack-build-infra/ruby-2.3:0.5
       args:
       - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
       - "--root=/workspace"
@@ -74,17 +74,20 @@ log_level: info
   max_concurrency: 2
   agent: kubernetes
   spec:
-    # necessary for vagrant host to guest communication
-    hostNetwork: true
+    nodeSelector:
+      node-role.kubernetes.io/libvirt: ""
+    # Note: this is not supported yet by prow PodSpec, taint temporary removed
+    tolerations:
+    - effect: NoSchedule
+      key: dedicated
+      operator: Equal
     containers:
-    - image: gcr.io/jetstack-build-infra/ruby-2.3:0.4
+    - image: gcr.io/jetstack-build-infra/ruby-2.3:0.5
       args:
       - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
       - "--root=/workspace"
       - "--upload=gs://jetstack-logs/pr-logs"
       - "--clean"
-      securityContext:
-       privileged: true
       env:
       - name: BUNDLE_DIR
         value: /cache/bundle
@@ -96,14 +99,10 @@ log_level: info
         readOnly: true
       - name: bundle-cache
         mountPath: /cache/bundle
-      - name: dev-vboxdrv
-        mountPath: /dev/vboxdrv
-      - name: dev-vboxdrvu
-        mountPath: /dev/vboxdrvu
-      - name: dev-vboxnetctl
-        mountPath: /dev/vboxnetctl
       - name: vagrant-boxes
         mountPath: /root/.vagrant.d/boxes
+      - mountPath: /var/run/libvirt/libvirt-sock
+        name: var-run-libvirt-libvirt-sock
     volumes:
     - name: service
       secret:
@@ -116,18 +115,9 @@ log_level: info
       hostPath:
         path: /cache/vagrant-boxes
         type: Directory
-    - name: dev-vboxdrv
-      hostPath:
-        path: /dev/vboxdrv
-        type: CharDevice
-    - name: dev-vboxdrvu
-      hostPath:
-        path: /dev/vboxdrvu
-        type: CharDevice
-    - name: dev-vboxnetctl
-      hostPath:
-        path: /dev/vboxnetctl
-        type: CharDevice
+    - hostPath:
+        path: /var/run/libvirt/libvirt-sock
+        type: Socket
   trigger: "(?m)^/(re)?test( all| acceptance),?(\\s+|$)"
   rerun_command: "/test acceptance"
 


### PR DESCRIPTION
* no privileged container required
* relies on tolerations to make sure only neccessay workload get
targeted to the libvirt node