### PR TITLE
Set default org and project to 'dummy'

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -1,6 +1,6 @@
 ---
-default_org: jetstack
-default_repo: navigator
+default_org: dummy
+default_repo: dummy
 external_services:
   jetstack:
     gcs_bucket: jetstack-logs/


### PR DESCRIPTION
/cc @simonswine 

If we set it to any of our repos, we will then need to set the default in bootstrap.py too, and it gives us no advantages.

Chatting to upstream test-infra, the default repo is an older thing and it affects how URLs are passed by gubernator and determines where gubernator 'looks' for test files in GCS. Setting it to dummy makes the page [here](https://jetstack-build-infra.appspot.com/pr/jetstack/navigator/113) work (otherwise we'd need to do weird stuff to configure it to go to here: https://jetstack-build-infra.appspot.com/pr/jetstack/navigator/113 just for navigator