### PR TITLE
Use a finally block to execute cleanup commands

### DIFF
--- a/scenarios/minikube.py
+++ b/scenarios/minikube.py
@@ -16,7 +16,6 @@
 
 # Need to figure out why this only fails on travis
 # pylint: disable=bad-continuation
-
 """
 Executes a command, and cleans up minikube state for profile $HOSTNAME
 This should be run with the minikube-in-go job type
@@ -28,25 +27,28 @@ import subprocess
 import sys
 import socket
 
+
 def check(*cmd):
     """Log and run the command, raising on errors."""
-    print >>sys.stderr, 'Run:', cmd
-    exception = None
+    print >> sys.stderr, 'Run:', cmd
     try:
         subprocess.check_call(cmd)
-    except:
-        exception = sys.exc_info()[0]
-        pass # handle errors in the called executable
-    subprocess.call(["minikube", "delete", "--profile=%s" % socket.gethostname()])
-    subprocess.call(["rm", "-Rf", "/var/lib/libvirt/caches/minikube/.minikube/machines/%s" % socket.gethostname()])
-    if exception:
-        raise exception
+    finally:
+        subprocess.call(
+            ["minikube", "delete",
+             "--profile=%s" % socket.gethostname()])
+        subprocess.call([
+            "rm", "-Rf",
+            "/var/lib/libvirt/caches/minikube/.minikube/machines/%s" %
+            socket.gethostname()
+        ])
+
 
 def main(envs, cmd):
     """Run script and verify it exits 0."""
     for env in envs:
         key, val = env.split('=', 1)
-        print >>sys.stderr, '%s=%s' % (key, val)
+        print >> sys.stderr, '%s=%s' % (key, val)
         os.environ[key] = val
     if not cmd:
         raise ValueError(cmd)


### PR DESCRIPTION
Fixes: #52 

Tested locally.

```
./scenarios/minikube.py --env FOO=BARIO /bin/false 
FOO=BARIO
Run: ('/bin/false',)
Deleting local Kubernetes cluster...
Errors occurred deleting machine:  Error deleting host: drax: Error loading host from store: Host does not exist: "drax"
Traceback (most recent call last):
  File "./scenarios/minikube.py", line 64, in <module>
    main(ARGS.env, ARGS.cmd + ARGS.args)
  File "./scenarios/minikube.py", line 55, in main
    check(*cmd)
  File "./scenarios/minikube.py", line 35, in check
    subprocess.check_call(cmd)
  File "/usr/lib64/python2.7/subprocess.py", line 186, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '('/bin/false',)' returned non-zero exit status 1
```


```
./scenarios/minikube.py --env FOO=BARIO /bin/env
...
FOO=BARIO
Deleting local Kubernetes cluster...
Errors occurred deleting machine:  Error deleting host: drax: Error loading host from store: Host does not exist: "drax"
```