### PR TITLE
Use the minikube in-tree kvm2 driver

### DIFF
--- a/images/minikube-in-go/Dockerfile
+++ b/images/minikube-in-go/Dockerfile
@@ -44,16 +44,13 @@ RUN apt-get update \
         zlib1g-dev \
     && apt-get clean
 
-RUN curl -L https://github.com/docker/machine/releases/download/v0.13.0/docker-machine-Linux-x86_64 >/tmp/docker-machine \
-    && chmod +x /tmp/docker-machine \
-    && cp /tmp/docker-machine /usr/local/bin/docker-machine
-
+RUN curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-kvm2 && \
+    chmod +x docker-machine-driver-kvm2 && \
+    mv docker-machine-driver-kvm2 /usr/bin/
 RUN wget https://storage.googleapis.com/golang/go1.9.1.linux-amd64.tar.gz && \
-	tar -C /usr/local -xzf go1.9.1.linux-amd64.tar.gz
+  tar -C /usr/local -xzf go1.9.1.linux-amd64.tar.gz
 ENV PATH "/usr/local/go/bin:/go/bin:${PATH}"
 ENV GOPATH "/go"
-
-RUN go get -v github.com/dhiltgen/docker-machine-kvm/cmd/docker-machine-driver-kvm
 
 ENV GCLOUD_VERSION 163.0.0
 RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-$GCLOUD_VERSION-linux-x86_64.tar.gz && \

--- a/scenarios/minikube.py
+++ b/scenarios/minikube.py
@@ -32,7 +32,7 @@ hostname = socket.gethostname()
 minikube_start_cmd = [
     "minikube",
     "start",
-    "--vm-driver=kvm",
+    "--vm-driver=kvm2",
     "--kubernetes-version=%s" % os.environ["KUBERNETES_VERSION"],
     "--bootstrapper=kubeadm",
     "--memory=4096",


### PR DESCRIPTION
I noticed the following warning when running E2E tests.

```
W0111 13:56:51.857] WARNING: The kvm driver is now deprecated and support for it will be removed in a future release.
W0111 13:56:51.858] 				Please consider switching to the kvm2 driver, which is intended to replace the kvm driver.
W0111 13:56:51.858] 				See https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#kvm2-driver for more information.
W0111 13:56:51.858] 				To disable this message, run [minikube config set WantShowDriverDeprecationNotification false]

```

https://jetstack-build-infra.appspot.com/build/jetstack-logs/pr-logs/pull/jetstack_navigator/142/navigator-e2e-v1-9/33/

There's a new "kvm2" driver maintained and recommended by the minikube people, since:
 * https://github.com/kubernetes/minikube/pull/1828
