### PR TITLE
jobs/cert-manager: add 'verify_pr' to verify

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -262,6 +262,7 @@
     "args": [
       "make",
       "verify",
+      "verify_pr",
       "test"
     ],
     "scenario": "execute",


### PR DESCRIPTION
This goes along with https://github.com/jetstack/cert-manager/pull/397, see the change there for justification why.