### PR TITLE
Run puppet modules tarmak for different versions

### DIFF
--- a/jobs/config.json
+++ b/jobs/config.json
@@ -264,7 +264,7 @@
       "UNKNOWN"
     ]
   },
-  "tarmak-puppet-module-kubernetes-acceptance-1-10-centos": {
+  "tarmak-puppet-module-tarmak-acceptance-1-10-centos": {
     "args": [
       "--env",
       "FIXTURES_YML=.fixtures.yml.local",
@@ -279,7 +279,7 @@
       "UNKNOWN"
     ]
   },
-  "tarmak-puppet-module-kubernetes-acceptance-1-9-centos": {
+  "tarmak-puppet-module-tarmak-acceptance-1-9-centos": {
     "args": [
       "--env",
       "FIXTURES_YML=.fixtures.yml.local",
@@ -288,6 +288,66 @@
       "-C",
       "puppet/modules/tarmak",
       "acceptance-1-9-centos"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  },
+  "tarmak-puppet-module-tarmak-acceptance-1-8-centos": {
+    "args": [
+      "--env",
+      "FIXTURES_YML=.fixtures.yml.local",
+      "--",
+      "make",
+      "-C",
+      "puppet/modules/tarmak",
+      "acceptance-1-8-centos"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  },
+  "tarmak-puppet-module-tarmak-acceptance-1-7-centos": {
+    "args": [
+      "--env",
+      "FIXTURES_YML=.fixtures.yml.local",
+      "--",
+      "make",
+      "-C",
+      "puppet/modules/tarmak",
+      "acceptance-1-7-centos"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  },
+  "tarmak-puppet-module-tarmak-acceptance-1-6-centos": {
+    "args": [
+      "--env",
+      "FIXTURES_YML=.fixtures.yml.local",
+      "--",
+      "make",
+      "-C",
+      "puppet/modules/tarmak",
+      "acceptance-1-6-centos"
+    ],
+    "scenario": "execute",
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  },
+  "tarmak-puppet-module-tarmak-acceptance-1-9-ubuntu": {
+    "args": [
+      "--env",
+      "FIXTURES_YML=.fixtures.yml.local",
+      "--",
+      "make",
+      "-C",
+      "puppet/modules/tarmak",
+      "acceptance-1-9-ubuntu"
     ],
     "scenario": "execute",
     "sigOwners": [

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -777,6 +777,43 @@ presubmits:
     run_if_changed: "^(puppet/modules).*$"
     trigger: "(?m)^/test( all| puppet| puppet-tarmak| puppet-tarmak-acceptance-centos( v?1.9)?|)( \\[.+\\])?$"
     rerun_command: "/test puppet-tarmak-acceptance-centos v1.9"
+    run_after_success:
+    - <<: *puppet_module_acceptance
+      name: tarmak-puppet-module-tarmak-acceptance-1-9-ubuntu
+      context: tarmak-puppet-module-tarmak-acceptance-1-9-ubuntu
+      run_if_changed: "^(puppet/modules).*$"
+      trigger: "(?m)^/test( all| puppet| puppet-tarmak| puppet-tarmak-acceptance-ubuntu( v?1.9)?|)( \\[.+\\])?$"
+      rerun_command: "/test puppet-tarmak-acceptance-ubuntu v1.9"
+    - <<: *puppet_module_acceptance
+      name: tarmak-puppet-module-tarmak-acceptance-1-10-centos
+      context: tarmak-puppet-module-tarmak-acceptance-1-10-centos
+      run_if_changed: "^(puppet/modules).*$"
+      trigger: "(?m)^/test( all| puppet| puppet-tarmak| puppet-tarmak-acceptance-centos( v?1.10)?|)( \\[.+\\])?$"
+      rerun_command: "/test puppet-tarmak-acceptance-centos v1.10"
+    - <<: *puppet_module_acceptance
+      name: tarmak-puppet-module-tarmak-acceptance-1-8-centos
+      context: tarmak-puppet-module-tarmak-acceptance-1-8-centos
+      run_if_changed: "^(puppet/modules).*$"
+      trigger: "(?m)^/test( all| puppet| puppet-tarmak| puppet-tarmak-acceptance-centos( v?1.8)?|)( \\[.+\\])?$"
+      rerun_command: "/test puppet-tarmak-acceptance-centos v1.8"
+    - <<: *puppet_module_acceptance
+      name: tarmak-puppet-module-tarmak-acceptance-1-7-centos
+      context: tarmak-puppet-module-tarmak-acceptance-1-7-centos
+      run_if_changed: "^(puppet/modules).*$"
+      trigger: "(?m)^/test( all| puppet| puppet-tarmak| puppet-tarmak-acceptance-centos( v?1.7)?|)( \\[.+\\])?$"
+      rerun_command: "/test puppet-tarmak-acceptance-centos v1.7"
+    - <<: *puppet_module_acceptance
+      name: tarmak-puppet-module-tarmak-acceptance-1-6-centos
+      context: tarmak-puppet-module-tarmak-acceptance-1-6-centos
+      run_if_changed: "^(puppet/modules).*$"
+      trigger: "(?m)^/test( all| puppet| puppet-tarmak| puppet-tarmak-acceptance-centos( v?1.6)?|)( \\[.+\\])?$"
+      rerun_command: "/test puppet-tarmak-acceptance-centos v1.6"
+    - <<: *puppet_module_acceptance
+      name: tarmak-puppet-module-tarmak-acceptance-1-10-centos
+      context: tarmak-puppet-module-tarmak-acceptance-1-10-centos
+      run_if_changed: "^(puppet/modules).*$"
+      trigger: "(?m)^/test( all| puppet| puppet-tarmak| puppet-tarmak-acceptance-centos( v?1.10)?|)( \\[.+\\])?$"
+      rerun_command: "/test puppet-tarmak-acceptance-centos v1.10"
 
   - name: tarmak-quick-verify
     always_run: true


### PR DESCRIPTION
First try to run puppet acceptance for the main supported version. Once
this passes run all tests for different versions.

/cc @munnerz 
