### PR TITLE
Update minikube jobs to have more CPUs & memory

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -76,9 +76,9 @@ presets:
     minikube-size: small
   env:
   - name: MINIKUBE_CPUS
-    value: "2"
+    value: "3"
   - name: MINIKUBE_MEMORY
-    value: "4096"
+    value: "8192"
 
 # storage / caching presets
 - labels:
@@ -103,8 +103,8 @@ presets:
 .minikube_small: &minikube_small
   resources:
     requests:
-      cpu: 1800m
-      memory: 4Gi
+      cpu: 2900m
+      memory: 8Gi
 
 tide:
   target_url: https://prow.build-infra.jetstack.net/tide.html


### PR DESCRIPTION
When cert-manager e2e jobs that deploy boulder are run, they are failing due to timeouts. I think this is because we have few, large nodes and resources are getting starved.

This increases the allocation for these jobs.

In future, once the ACMEv2 branch has merged, I'll revert this change.