### PR TITLE
Enable persistent local volumes

### DIFF
--- a/scenarios/minikube.py
+++ b/scenarios/minikube.py
@@ -38,6 +38,7 @@ minikube_start_cmd = [
     "--memory=%s" % os.environ["MINIKUBE_MEMORY"],
     "--cpus=%s" % os.environ["MINIKUBE_CPUS"],
     "--profile=%s" % hostname,
+    "--feature-gates=PersistentLocalVolumes=true",
 ]
 
 minikube_ingress_cmd = [


### PR DESCRIPTION
I want to be able to run Navigator E2E tests for Cassandra on a multi-node dind-cluster, but tests keep failing because currently we're using host-path volumes which are not locked to a single node.
 * https://github.com/jetstack/navigator/pull/330
 * https://jetstack-build-infra.appspot.com/build/jetstack-logs/pr-logs/pull/jetstack_navigator/330/navigator-e2e-v1-9/696/

```
W0413 18:57:38.880] + kubectl create --filename -
W0413 18:57:39.123] The PersistentVolume "test-cassandra-1523645566-23842-pv1" is invalid: 
W0413 18:57:39.124] * metadata.annotations: Forbidden: Storage node affinity is disabled by feature-gate
W0413 18:57:39.124] * spec.local: Forbidden: Local volumes are disabled by feature-gate
```

Easiest fix is to use local volumes instead, which works fine on dind-cluster but not then on minikube.

Let's enable PersistentLocalVolumes so that I can run the tests in both environments:
 * https://github.com/kubernetes-incubator/external-storage/tree/local-volume-provisioner-v2.0.0/local-volume#step-1-bringing-up-a-cluster-with-local-disks

