### PR TITLE
Add experimental dind based cert-manager verify presubmit

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
-build --workspace_status_command=./print-workspace-status.sh
-run --workspace_status_command=./print-workspace-status.sh
+#build --workspace_status_command=./print-workspace-status.sh
+#run --workspace_status_command=./print-workspace-status.sh
 test --features=race --test_output=errors
 
 # you can run only lint tests with:

--- a/images/bootstrap/Makefile
+++ b/images/bootstrap/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMG = gcr.io/k8s-testimages/bootstrap
+IMG = gcr.io/jetstack-build-infra/bootstrap
 TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 all: build

--- a/images/bootstrap/runner
+++ b/images/bootstrap/runner
@@ -18,7 +18,7 @@ set -o nounset
 set -o pipefail
 
 # get test-infra for latest bootstrap etc
-git clone https://github.com/kubernetes/test-infra
+git clone https://github.com/jetstack/test-infra
 
 
 # Check if the job has opted-in to bazel remote caching and if so generate 
@@ -75,7 +75,7 @@ set +o errexit
 ./test-infra/jenkins/bootstrap.py \
     --job=${JOB_NAME} \
     --service-account=${GOOGLE_APPLICATION_CREDENTIALS} \
-    --upload='gs://kubernetes-jenkins/logs' \
+    --upload='gs://jetstack-logs/pr-logs' \
     "$@"
 EXIT_VALUE=$?
 

--- a/images/cert-manager-test/Dockerfile-0.3
+++ b/images/cert-manager-test/Dockerfile-0.3
@@ -1,0 +1,54 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file creates a build environment for building and running kubernetes
+# unit and integration tests
+
+FROM golang:1.10.2
+LABEL authors="James Munnelly <james@jetstack.io>"
+
+# Setup workspace and symlink to gopath
+WORKDIR /workspace
+RUN mkdir -p /go/src/github.com/jetstack/cert-manager /workspace \
+    && ln -s /go/src/github.com/jetstack/cert-manager /workspace/cert-manager
+ENV WORKSPACE=/workspace \
+    TERM=xterm
+
+# Install linux packages
+# bc is needed by shell2junit
+# dnsutils is needed by federation cluster scripts.
+# file is used when uploading test artifacts to GCS.
+# jq is used by hack/verify-godep-licenses.sh
+# python-pip is needed to install the AWS cli.
+# netcat is used by integration test scripts.
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y \
+        bc \
+	dnsutils \
+	file \
+	jq \
+	python-pip \
+	netcat-openbsd \
+	rsync \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 >/tmp/dep \
+    && curl -L https://github.com/mikefarah/yaml/releases/download/1.13.1/yaml_linux_amd64 >/tmp/yaml \
+    && curl -L vert https://github.com/Masterminds/vert/releases/download/v0.1.0/vert-v0.1.0-linux-amd64 >/tmp/vert \
+    && chmod +x /tmp/dep \
+    && chmod +x /tmp/yaml \
+    && chmod +x /tmp/vert \
+    && mv /tmp/dep /tmp/yaml /tmp/vert /usr/local/bin/
+RUN go get -v golang.org/x/tools/cmd/goimports \
+    && go get -v github.com/golang/lint/golint

--- a/images/cert-manager-test/Makefile
+++ b/images/cert-manager-test/Makefile
@@ -1,0 +1,52 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMG = eu.gcr.io/jetstack-build-infra/cert-manager-test
+TAG = $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+VERSIONS := $(wildcard ./Dockerfile-*)
+
+do_build = \
+	$(eval VERSION := $(subst ./Dockerfile-,,$(v)))\
+	docker build -f ./Dockerfile-$(VERSION) -t $(IMG):$(VERSION)-$(TAG) . ;\
+	docker tag $(IMG):$(VERSION)-$(TAG) $(IMG):$(VERSION)-latest ;\
+	echo Built $(IMG):$(VERSION)-$(TAG) and tagged with $(IMG):$(VERSION)-latest ;
+
+do_push = \
+	$(eval VERSION := $(subst ./Dockerfile-,,$(v)))\
+	docker push $(IMG):$(VERSION)-$(TAG);\
+	docker push $(IMG):$(VERSION)-latest;\
+	echo Pushed $(IMG):$(VERSION)-latest and $(IMG):$(VERSION)-$(TAG);
+
+.PHONY: all build push help
+
+all: build
+
+build:
+	@$(foreach v,$(VERSIONS),$(do_build))
+
+push: build
+	@$(foreach v,$(VERSIONS),$(do_push))
+
+help:
+	@echo "VARIABLES:"
+	@echo " VERSIONS:       Dockerfile to be built/pushed, can be either full file name or a tag"
+	@echo " 				- make build VERSIONS=./Dockerfile-0.3"
+	@echo " 				- make build VERSIONS=0.3"
+	@echo " 				are equivalent and both valid."
+	@echo ""
+	@echo "TARGETS:"
+	@echo " all:            build"
+	@echo " build:      	builds all the Dockerfile-* in VERSIONS"
+	@echo " push:       	builds all the Dockerfile-* in VERSIONS and pushes to jetstack-build-infra"
+

--- a/images/cert-manager-test/README.md
+++ b/images/cert-manager-test/README.md
@@ -1,0 +1,9 @@
+# cert-manager-test
+
+This image defines an environment for running cert-manager unit and integration
+tests.
+
+This is primarily used by the pull-cert-manager-verify job.
+
+We provide a build image per minor version, to allow for divergences in the build
+process when maintaining old branches.

--- a/jobs/config.json
+++ b/jobs/config.json
@@ -599,6 +599,16 @@
       "UNKNOWN"
     ]
   },
+  "pull-cert-manager-verify": {
+    "args": [
+      "--branch=${PULL_BASE_REF}",
+      "--script=./hack/ci/test-dockerized.sh"
+    ],
+    "scenario": "cert-manager_verify",
+    "sigOwners": [
+      "UNKNOWN"
+    ]
+  },
   "navigator-quick-verify": {
     "args": [
       "make",

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -525,6 +525,42 @@ presubmits:
         emptyDir: {}
 
   jetstack/cert-manager:
+
+  - name: pull-cert-manager-verify
+    always_run: false
+    skip_report: true
+    context: pull-cert-manager-verify
+    max_concurrency: 2
+    agent: kubernetes
+    labels:
+      preset-service-account: true
+    spec:
+      containers:
+      - image: eu.gcr.io/jetstack-build-infra/bootstrap:v20180509-c5b6943a5
+        args:
+        - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://jetstack-logs/pr-logs"
+        - "--clean"
+        resources:
+          requests:
+            cpu: 1
+            memory: 1Gi
+        env:
+        - name: DOCKER_IN_DOCKER_ENABLED
+          value: true
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: docker-graph
+          mountPath: /docker-graph
+      volumes:
+      - name: docker-graph
+        emptyDir: {}
+    trigger: "(?m)^/test( all| verify),?(\\s+|$)"
+    rerun_command: "/test verify"
+
   - name: cert-manager-quick-verify
     always_run: true
     skip_report: false

--- a/scenarios/cert-manager_verify.py
+++ b/scenarios/cert-manager_verify.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+# Copyright 2018 Jetstack Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=bad-continuation
+
+"""Runs verify/test-go checks for jetstack/cert-manager."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+BRANCH_VERSION = {
+    'master': '0.3',
+}
+
+VERSION_TAG = {
+    '0.3': '0.3-v20180509-28a07d6a6',
+}
+
+
+def check_output(*cmd):
+    """Log and run the command, return output, raising on errors."""
+    print >>sys.stderr, 'Run:', cmd
+    return subprocess.check_output(cmd)
+
+
+def check(*cmd):
+    """Log and run the command, raising on errors."""
+    print >>sys.stderr, 'Run:', cmd
+    subprocess.check_call(cmd)
+
+
+def retry(func, times=5):
+    """call func until it returns true at most times times"""
+    success = False
+    for _ in range(0, times):
+        success = func()
+        if success:
+            return success
+    return success
+
+
+def try_call(cmds):
+    """returns true if check(cmd) does not throw an exception
+    over all cmds where cmds = [[cmd, arg, arg2], [cmd2, arg]]"""
+    try:
+        for cmd in cmds:
+            check(*cmd)
+        return True
+    # pylint: disable=bare-except
+    except:
+        return False
+
+def main(branch, script, force, on_prow):
+    """Test branch using script, optionally forcing verify checks."""
+    # If branch has 3-part version, only take first 2 parts.
+    verify_branch = re.match(r'master|release-(\d+\.\d+)', branch)
+    if not verify_branch:
+        raise ValueError(branch)
+    # Extract version if any.
+    ver = verify_branch.group(1) or verify_branch.group(0)
+    tag = VERSION_TAG[BRANCH_VERSION.get(ver, ver)]
+    force = 'y' if force else 'n'
+    artifacts = '%s/_artifacts' % os.environ['WORKSPACE']
+    k8s = os.getcwd()
+    if not os.path.basename(k8s) == 'cert-manager':
+        raise ValueError(k8s)
+
+    check('rm', '-rf', '.gsutil')
+    remote = 'bootstrap-upstream'
+    uri = 'https://github.com/jetstack/cert-manager.git'
+
+    current_remotes = check_output('git', 'remote')
+    if re.search('^%s$' % remote, current_remotes, flags=re.MULTILINE):
+        check('git', 'remote', 'remove', remote)
+    check('git', 'remote', 'add', remote, uri)
+    check('git', 'remote', 'set-url', '--push', remote, 'no_push')
+    # If .git is cached between runs this data may be stale
+    check('git', 'fetch', remote)
+
+    if not os.path.isdir(artifacts):
+        os.makedirs(artifacts)
+
+    # TODO(bentheelder): on prow REPO_DIR should be /go/src/k8s.io/kubernetes
+    # however these paths are brittle enough as is...
+    cmd = [
+        'docker', 'run', '--rm=true', '--privileged=true',
+        '-v', '/var/run/docker.sock:/var/run/docker.sock',
+        '-v', '/etc/localtime:/etc/localtime:ro',
+        '-v', '%s:/go/src/github.com/jetstack/cert-manager' % k8s,
+        '-v', '%s:/workspace/artifacts' % artifacts,
+        '-e', 'KUBE_FORCE_VERIFY_CHECKS=%s' % force,
+        '--tmpfs', '/tmp:exec,mode=1777',
+        'eu.gcr.io/jetstack-build-infra/cert-manager-test:%s' % tag,
+        'bash', '-c', 'cd cert-manager && %s' % script,
+    ]
+    check(*cmd)
+
+
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser(
+        'Runs verification checks on the cert-manager repo')
+    PARSER.add_argument(
+        '--branch', default='master', help='Upstream target repo')
+    PARSER.add_argument(
+        '--force', action='store_true', help='Force all verify checks')
+    PARSER.add_argument(
+        '--script',
+        default='./hack/ci/test-dockerized.sh',
+        help='Script in jetstack/cert-manager that runs checks')
+    PARSER.add_argument(
+        '--prow', action='store_true', help='Force Prow mode'
+    )
+    ARGS = PARSER.parse_args()
+    main(ARGS.branch, ARGS.script, ARGS.force, ARGS.prow)


### PR DESCRIPTION
As discussed with @simonswine - the first stage of testing to get dind based testing running.

This needs merging now in order to test, due to the way the bootstrap script works (it clones master of this repo)