### PR TITLE
Add alpine image

### DIFF
--- a/images/alpine/Dockerfile
+++ b/images/alpine/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2018 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.7
+
+RUN apk add --no-cache ca-certificates && \
+  addgroup -S user && adduser -S -G user user
+
+USER user

--- a/images/alpine/Makefile
+++ b/images/alpine/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+IMG = gcr.io/jetstack-build-infra/bazelbuild
+
+# TODO(bentheelder): retire some of these as they become unnecessary
+ALPINE_VERSION=3.7
+TAG := ${ALPINE_VERSION}-$(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
+
+image:
+	docker build --build-arg ALPINE_VERSION=$(ALPINE_VERSION) -t "gcr.io/jetstack-build-infra/alpine:$(TAG)" .
+
+push: image
+	gcloud docker -- push "gcr.io/jetstack-build-infra/alpine:$(TAG)"
+
+.PHONY: image push


### PR DESCRIPTION
Adds an alpine image with ca-certificates for use by cert-manager's bazel build process