### PR TITLE
Disable dco bot for cert-manager

### DIFF
--- a/prow/plugins.yaml
+++ b/prow/plugins.yaml
@@ -108,7 +108,6 @@ plugins:
   - yuks
   - wip
   - shrug
-  - dco
 
   jetstack/kube-lego:
   - docs-no-retest


### PR DESCRIPTION
Temporary whilst we sort out issues with over-commenting